### PR TITLE
Fix reference to wc.js direct descendent selectors which break in custom elements (not just svelte-retag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 vite.config.ts.timestamp-*
 pnpm-lock.yaml
+.idea/

--- a/index.html
+++ b/index.html
@@ -74,6 +74,6 @@
             </scrollephant-navigations-wrapper>
         </scrollephant-root>
 
-        <script type="module" src="/dist/wc.js"></script>
+        <script type="module" src="src/package/wc.js"></script>
     </body>
 </html>

--- a/src/package/ScrollephantWrapper.svelte
+++ b/src/package/ScrollephantWrapper.svelte
@@ -14,7 +14,7 @@
     }
 
     :global(.scrollephant[data-scrollephant-direction="vertical"])
-        > .scrollephant-wrapper,
+         .scrollephant-wrapper,
     :global(
             .scrollephant[data-scrollephant-direction="horizontal"]
                 [data-scrollephant-have-subsection="true"]
@@ -25,7 +25,7 @@
     }
 
     :global(.scrollephant[data-scrollephant-direction="horizontal"])
-        > .scrollephant-wrapper,
+         .scrollephant-wrapper,
     :global(
             .scrollephant[data-scrollephant-direction="vertical"]
                 [data-scrollephant-have-subsection="true"]


### PR DESCRIPTION
See full explanation in discussion here: https://github.com/patricknelson/svelte-retag/discussions/49#discussioncomment-7948109

Fixes `svelte-retag` custom element driven demo. 😎 Awesome carousel, btw!

![2023-12-26_03-12-18](https://github.com/babakfp/scrollephant/assets/4269377/1ec556ee-a828-4565-b856-2ea4fe2510a5)
